### PR TITLE
49 suggest add grouping for environment executions to support starting envrionment by groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,16 @@ Or you could also check the list of commands below in the [Available Commands](#
 | dever [keyword] env | shows help context for dever env options |
 | dever [keyword] env | shows help context for dever env [keyword] options |
 | dever [keyword] env --start | attempts to start environment |
-| dever [keyword] env --start [name] | attempts to start environment except only the runtime given |
-| dever [keyword] env --start --not [name] | attempts to start environment except those mentioned in the --not option |
+| dever [keyword] env --start [name] | attempts to start only specified environment dependencies |
+| dever [keyword] env --start --not [name] | attempts to start environment dependencies except those mentioned in the --not option |
+| dever [keyword] env --start --not-group [name] | attempts to start environment dependencies expect those grouped in the --not-group option |
 | dever [keyword] env --stop | attempts to stop environment |
-| dever [keyword] env --stop --not [name] | attempts to stop environment except those mentioned in the --not option |
+| dever [keyword] env --stop --not [name] | attempts to stop environment dependencies except those mentioned in the --not option |
+| dever [keyword] env --stop --not-group [name] | attempts to stop environment dependencies expect those grouped in the --not-group option |
 | dever [keyword] env --start --clean | attempts to start environment cleanly e.g. recreating docker containers |
 | dever [keyword] env --start --skip | attempts to start environment without any need for confirmations |
+| dever [keyword] env --start-group [name] | attempts start grouped environment dependencies |
+| dever [keyword] env --stop-group [name] | attempts to stop grouped environment dependencies |
 | dever [keyword] env --location | shows location of project dever.json |
 | dever [keyword] env -c, --config | shows content of project dever.json |
 | dever [keyword] fix | Show help context for fix command |

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ Or you could also check the list of commands below in the [Available Commands](#
 | dever [keyword] env | shows help context for dever env [keyword] options |
 | dever [keyword] env --start | attempts to start environment |
 | dever [keyword] env --start [name] | attempts to start only specified environment dependencies |
-| dever [keyword] env --start --not [name] | attempts to start environment dependencies except those mentioned in the --not option |
-| dever [keyword] env --start --not-group [name] | attempts to start environment dependencies expect those grouped in the --not-group option |
+| dever [keyword] env --start --not [name], -n [name] | attempts to start environment dependencies except those mentioned in the --not option |
+| dever [keyword] env --start --not-group [name], --ng [name] | attempts to start environment dependencies expect those grouped in the --not-group option |
 | dever [keyword] env --stop | attempts to stop environment |
-| dever [keyword] env --stop --not [name] | attempts to stop environment dependencies except those mentioned in the --not option |
-| dever [keyword] env --stop --not-group [name] | attempts to stop environment dependencies expect those grouped in the --not-group option |
+| dever [keyword] env --stop --not [name], -n [name] | attempts to stop environment dependencies except those mentioned in the --not option |
+| dever [keyword] env --stop --not-group [name], --ng [name] | attempts to stop environment dependencies expect those grouped in the --not-group option |
 | dever [keyword] env --start --clean | attempts to start environment cleanly e.g. recreating docker containers |
 | dever [keyword] env --start --skip | attempts to start environment without any need for confirmations |
 | dever [keyword] env --start-group [name] | attempts start grouped environment dependencies |

--- a/bin/configuration/models.js
+++ b/bin/configuration/models.js
@@ -45,57 +45,57 @@ class Config {
 class Execution {
     /**
      * Define which handler you're using ('docker-container','powershell-command','powershell-script','docker-compose','mssql')
-     * @return {string}
+     * @type {string}
      */
     type;
 
     /**
-     * @return {string}
+     * @type {string}
      */
     name;
 
     /**
-     * @return {boolean}
+     * @type {string | null}
      */
-    runtime;
+    group;
 
     /**
-     * @return {string}
+     * @type {string | null}
      */
     file;
 
     /**
-     * @return {string}
+     * @type {string | null}
      */
     command;
 
     /**
      * Sql object only used when type is 'mssql'
-     * @return {DbQuery | null}
+     * @type {DbQuery | null}
      */
     sql;
 
     /**
      * Container object only used when type is 'docker-container'
-     * @return {Container | null}
+     * @type {Container | null}
      */
     container;
 
     /**
      * Custom options that will be passed along to dependency
-     * @return {CustomOption[] | null}
+     * @type {CustomOption[] | null}
      */
     options;
     // Todo: Consider new name for this property
 
     /**
-     * @return {Wait}
+     * @type {Wait | null}
      */
     wait;
 
     /**
      * Informs whether a dependency needs to be run as elevated user
-     * @return {boolean}
+     * @type {boolean | null}
      */
     runAsElevated;
 }

--- a/bin/environments/index.js
+++ b/bin/environments/index.js
@@ -87,6 +87,11 @@ module.exports = new class {
             return;
         }
 
+        if (!this.#validate(config.environment)) {
+            console.error(chalk.redBright(`One or more of the executions are either missing type or name!`));
+            return;
+        }
+
         if (!this.#checkAvailabilityOfDependencies(config.environment)) {
             return;
         }
@@ -96,12 +101,8 @@ module.exports = new class {
         }
 
         for (const execution of config.environment) {
-            if (execution.type == null) {
-                console.error(chalk.redBright(`${execution.name}: Missing type!`));
-                return;
-            }
-            if ((execution.runtime && runtime.variables.length > 0 && !runtime.variables.some(x => x === execution.name)) ||
-                runtime.not.length > 0 && runtime.not.some(x => x.toLowerCase() === execution.name?.toLowerCase())) {
+            if (runtime.variables.length > 0 && !runtime.variables.some(x => x.toLowerCase() === execution.name) ||
+                runtime.not.length > 0 && runtime.not.some(x => x.toLowerCase() === execution.name.toLowerCase())) {
                 continue;
             }
 
@@ -257,6 +258,14 @@ module.exports = new class {
         }
 
         return true;
+    }
+
+    /**
+     * Validate executions
+     * @param executions {Execution[]}
+     */
+    #validate(executions) {
+        return !executions.some(x => x.name == null || x.type == null);
     }
 
     /**


### PR DESCRIPTION
## Describe your changes
* Added support for starting individual executions without having runtime flag.
* Added support for grouping executions with name and creating new options for starting and not starting executions.

## Issue ticket number and link
[#49 [Suggest] Add grouping for environment executions to support starting envrionment by groups](/../../issues/49)

## Checklist before requesting a review
✔️  I have read and followed [guidelines for contributing](CONTRIBUTING.md) to this repository
✔️  I have performed a self-review of my code
✔️  I have followed the commit's or even all commits' message styles matches our requested structure.

Closes #49 