### PR TITLE
#59 bug dever init throws an error and therefore cannot add dever supported projects

### DIFF
--- a/bin/common/helper/powershell.js
+++ b/bin/common/helper/powershell.js
@@ -63,7 +63,7 @@ module.exports = new class {
         return execSync(`powershell.exe -ExecutionPolicy Bypass -File ${file}`, {
             shell: 'powershell.exe',
             encoding: 'utf8',
-            stdio: ['ignore', 'ignore']
+            stdio: ['ignore']
         });
     }
 

--- a/bin/init.js
+++ b/bin/init.js
@@ -38,6 +38,11 @@ module.exports = new class {
         projectsConfig.clear();
 
         const raw = await powershell.executeFileSync(file);
+        if (raw == null || raw?.length === 0) {
+            console.error(chalk.yellow('Could not find any dever supported projects'));
+            return;
+        }
+
         const paths = raw.trim().split('\n');
 
         for (const path of paths) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@czprz/dever",
-  "version": "0.10.0-beta",
+  "version": "0.10.1-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@czprz/dever",
-      "version": "0.10.0-beta",
+      "version": "0.10.1-beta",
       "license": "Unlicense",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@czprz/dever",
-  "version": "0.10.0-beta",
+  "version": "0.10.1-beta",
   "description": "Development Helper (dev-er) to speed up and keep local development environment consistent",
   "author": "Casper Overholm Elkrog",
   "keywords": [


### PR DESCRIPTION
## Describe your changes
Removed 'ignore' that was causing the return message to be the wrong value and added a null or empty check for 'dever init' to avoid continuing checking the found projects when nothing has been found

## Issue ticket number and link
[#59 [bug] 'dever init' throws an error and therefore cannot add dever supported projects](/../../issues/59)

## Checklist before requesting a review
✔️  I have read and followed [guidelines for contributing](CONTRIBUTING.md) to this repository
✔️  I have performed a self-review of my code
✔️  I have followed the commit's or even all commits' message styles matches our requested structure.

Closes #59 
