### PR TITLE
#71 bug cannot run dever keyword env start which uses powershell when deverjson path has spaces

### DIFF
--- a/bin/common/helper/powershell.js
+++ b/bin/common/helper/powershell.js
@@ -53,14 +53,14 @@ module.exports = new class {
         if (await this.#shouldRunElevated(elevated)) {
             const timer = delayer.create();
 
-            sudo.command(`powershell.exe -ExecutionPolicy Bypass -File ${file}`, 'Powershell', (error) => {
+            sudo.command(`powershell.exe -ExecutionPolicy Bypass -File "${file}"`, 'Powershell', (error) => {
                 timer.done(error == null);
             });
 
             return timer.delay(36000000, 'Powershell could not execute as during waiting for elevated permission prompt expired');
         }
 
-        return execSync(`powershell.exe -ExecutionPolicy Bypass -File ${file}`, {
+        return execSync(`powershell.exe -ExecutionPolicy Bypass -File "${file}"`, {
             shell: 'powershell.exe',
             encoding: 'utf8',
             stdio: ['ignore']

--- a/bin/environments/executions/docker-compose/index.js
+++ b/bin/environments/executions/docker-compose/index.js
@@ -52,7 +52,7 @@ module.exports = new class {
                 }
 
                 const filePath = path.join(component.location, execution.file);
-                shell.executeSync(`docker-compose --file ${filePath} --project-name dever up -d`);
+                shell.executeSync(`docker-compose --file "${filePath}" --project-name dever up -d`);
                 break;
             }
             case states.Running: {
@@ -65,7 +65,7 @@ module.exports = new class {
             }
             case states.NotFound: {
                 const filePath = path.join(component.location, execution.file);
-                shell.executeSync(`docker-compose --file ${filePath} --project-name dever up -d`);
+                shell.executeSync(`docker-compose --file "${filePath}" --project-name dever up -d`);
                 console.log(`docker-compose: '${execution.name}' created successfully`);
                 break;
             }
@@ -85,7 +85,7 @@ module.exports = new class {
         }
 
         const filePath = path.join(component.location, file);
-        shell.executeSync(`docker-compose --file ${filePath} --project-name dever up -d --force-recreate`);
+        shell.executeSync(`docker-compose --file "${filePath}" --project-name dever up -d --force-recreate`);
 
         console.log(`docker-compose: '${name}' recreated successfully`);
 
@@ -99,7 +99,7 @@ module.exports = new class {
      */
     #stop(component, execution) {
         const filePath = path.join(component.location, execution.file);
-        shell.executeSync(`docker-compose --file ${filePath} --project-name dever down`);
+        shell.executeSync(`docker-compose --file "${filePath}" --project-name dever down`);
 
         console.log(`docker-compose: '${execution.name}' stopped successfully`);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@czprz/dever",
-  "version": "0.10.2-beta",
+  "version": "0.10.3-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@czprz/dever",
-      "version": "0.10.2-beta",
+      "version": "0.10.3-beta",
       "license": "Unlicense",
       "dependencies": {
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@czprz/dever",
-  "version": "0.10.2-beta",
+  "version": "0.10.3-beta",
   "description": "Development Helper (dev-er) to speed up and keep local development environment consistent",
   "author": "Casper Overholm Elkrog",
   "keywords": [


### PR DESCRIPTION
## Describe your changes
Added qoutes around file path in shell executions to support spaces in paths

## Issue ticket number and link
[#71 [bug] cannot run dever [keyword] env --start which uses powershell when dever.json path has spaces](/../../issues/71)

## Checklist before requesting a review
✔️ I have read and followed [guidelines for contributing](CONTRIBUTING.md) to this repository
✔️ I have performed a self-review of my code
✔️ I have followed the commit's or even all commits' message styles matches our requested structure.

Closes #71 