### PR TITLE
#92 Cannot use dever after upgrade conflicting dever

### DIFF
--- a/bin/configuration/local-config.js
+++ b/bin/configuration/local-config.js
@@ -21,7 +21,11 @@ export default new class {
      * @returns {LocalConfig}
      */
     get() {
-        const config = json.read(this.#filePath) ?? {projects: []};
+        const config = json.read(this.#filePath) ?? {projects: [], skipAllHashChecks: false};
+        // Todo: Temporary fix. Need to figure out a better way of handling upgrades of .dever
+        if (config.components != null) {
+            return {projects: [], skipAllHashChecks: false};
+        }
 
         const result = SchemaValidator.validate(SchemaTypes.DotDever, 1, config);
         if (!result) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@czprz/dever",
-  "version": "0.11.0-beta",
+  "version": "0.11.1-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@czprz/dever",
-      "version": "0.11.0-beta",
+      "version": "0.11.1-beta",
       "license": "Unlicense",
       "dependencies": {
         "ajv": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@czprz/dever",
-  "version": "0.11.0-beta",
+  "version": "0.11.1-beta",
   "description": "Development Helper (dev-er) to speed up and keep local development environment consistent",
   "author": "Casper Overholm Elkrog",
   "keywords": [


### PR DESCRIPTION
## Describe your changes
Fixed issue with getting .dever config and not aligning with new schema requirements

## Issue ticket number and link
[#92 Cannot use dever after upgrade. Conflicting .dever](../issues/92)

## Checklist before requesting a review
- ✔️ I have read and followed [guidelines for contributing](CONTRIBUTING.md) to this repository
- ✔️ I have performed a self-review of my code
- ✔️ I have made sure to create a pull request from a **topic/feature/bugfix** branch
- ✔️ I have followed the commit's or even all commits' message styles matches our requested structure.

Closes #92 