### PR TITLE
#105 Cannot use dever keyword env stop if one of the docker containers hasnt been created

### DIFF
--- a/bin/common/helper/mssql/validator.js
+++ b/bin/common/helper/mssql/validator.js
@@ -13,7 +13,7 @@ export default new class {
     }
 
     /**
-     * Check if conditions for creating database
+     * Check conditions for creating database
      * @param execution {Execution}
      * @return {Promise<boolean>}
      */
@@ -24,7 +24,7 @@ export default new class {
     }
 
     /**
-     * Check if conditions for creating table
+     * Check conditions for creating table
      * @param execution {Execution}
      * @return {Promise<boolean>}
      */
@@ -37,7 +37,7 @@ export default new class {
     }
 
     /**
-     * Check if conditions for inserting data
+     * Check conditions for creating columns
      * @param execution {Execution}
      * @return {Promise<boolean>}
      */
@@ -67,21 +67,7 @@ export default new class {
     }
 
     /**
-     * Checks if database name already exists
-     * @param execution {Execution}
-     * @returns {boolean|null}
-     */
-    #hasDatabaseName(execution) {
-        if (execution.sql?.database == null) {
-            console.log(`mssql: '${execution.name}' could not find database name`);
-            return false;
-        }
-
-        return null;
-    }
-
-    /**
-     * Checks if database name already exists
+     * Checks conditions for creating table
      * @param execution {Execution}
      * @returns {Promise<boolean|null>}
      */
@@ -95,7 +81,21 @@ export default new class {
     }
 
     /**
-     * Checks if database name already exists
+     * Checks if database property is set
+     * @param execution {Execution}
+     * @returns {boolean|null}
+     */
+    #hasDatabaseName(execution) {
+        if (execution.sql?.database == null) {
+            console.log(`mssql: '${execution.name}' could not find database name`);
+            return false;
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks if table property is set
      * @param execution {Execution}
      * @returns {boolean|null}
      */
@@ -109,7 +109,7 @@ export default new class {
     }
 
     /**
-     * Checks if database name already exists
+     * Checks if column property is set
      * @param execution {Execution}
      * @returns {boolean|null}
      */

--- a/bin/common/helper/mssql/validator.js
+++ b/bin/common/helper/mssql/validator.js
@@ -3,13 +3,23 @@ import mssql from '../../../common/helper/mssql/index.js';
 "use strict";
 export default new class {
     /**
+     * Check conditions for dropping database
+     * @return {Promise<boolean>}
+     */
+    async dropDatabase(execution) {
+        return this.#hasDatabaseName(execution) ??
+            await this.#hasDatabase(execution, true) ??
+            true;
+    }
+
+    /**
      * Check if conditions for creating database
      * @param execution {Execution}
      * @return {Promise<boolean>}
      */
     async createDatabase(execution) {
         return this.#hasDatabaseName(execution) ??
-            await this.#hasDatabase(execution) ??
+            await this.#hasDatabase(execution, false) ??
             true;
     }
 
@@ -41,11 +51,15 @@ export default new class {
     /**
      * Checks if database name already exists
      * @param execution {Execution}
+     * @param ignore {boolean}
      * @returns {Promise<boolean|null>}
      */
-    async #hasDatabase(execution) {
+    async #hasDatabase(execution, ignore) {
         if (await mssql.databaseExists(execution.sql)) {
-            console.log(`mssql: '${execution.name}' :: database already exists`);
+            if (!ignore) {
+                console.log(`mssql: '${execution.name}' :: database already exists`);
+            }
+
             return false;
         }
 
@@ -58,7 +72,7 @@ export default new class {
      * @returns {boolean|null}
      */
     #hasDatabaseName(execution) {
-        if (!execution.sql?.database) {
+        if (execution.sql?.database == null) {
             console.log(`mssql: '${execution.name}' could not find database name`);
             return false;
         }

--- a/bin/environments/executions/docker-container/index.js
+++ b/bin/environments/executions/docker-container/index.js
@@ -82,8 +82,19 @@ export default new class {
      * @param container {Container}
      */
     #stop(container) {
-        console.log(`docker-container: '${container.name}' has been stopped!`);
-        docker.container.stop(container.name);
+        const state = docker.container.getRunState(container.name);
+        switch (state) {
+            case docker.states.Running:
+                docker.container.stop(container.name);
+                console.log(`docker-container: '${container.name}' has been stopped!`);
+                break;
+            case docker.states.NotFound:
+                console.log(`docker-container: '${container.name}' not found!`);
+                break;
+            case docker.states.NotRunning:
+                console.log(`docker-container: '${container.name}' is not running!`);
+                break;
+        }
     }
 }
 

--- a/bin/environments/executions/mssql/index.js
+++ b/bin/environments/executions/mssql/index.js
@@ -93,14 +93,14 @@ export default new class {
 
     async #dropDatabase(execution) {
         try {
-            if (!await validator.createDatabase(execution)) {
+            if (await validator.dropDatabase(execution)) {
                 return;
             }
 
             await mssql.dropDatabase(execution.sql);
-            console.log(`mssql: '${execution.name}' :: database has been created`);
+            console.log(`mssql: '${execution.name}' :: database has been dropped`);
         } catch (e) {
-            logger.error(`mssql: '${execution.name}' :: database has not been created`, e);
+            logger.error(`mssql: '${execution.name}' :: database does not exist`, e);
         }
     }
 }

--- a/bin/environments/index.js
+++ b/bin/environments/index.js
@@ -356,9 +356,15 @@ export default new class {
      * @returns {Execution[]}
      */
     #getExecutions(config, runtime) {
-        return config.environment.map(x => {
+        const executions = config.environment.map(x => {
             return new Execution(x, runtime);
-        })
+        });
+
+        if (runtime.stop) {
+            return executions.reverse();
+        }
+
+        return executions;
     }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@czprz/dever",
-  "version": "0.11.5-beta",
+  "version": "0.11.6-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@czprz/dever",
-      "version": "0.11.5-beta",
+      "version": "0.11.6-beta",
       "license": "Unlicense",
       "dependencies": {
         "ajv": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@czprz/dever",
-  "version": "0.11.5-beta",
+  "version": "0.11.6-beta",
   "description": "Development Helper (dev-er) to speed up and keep local development environment consistent",
   "author": "Casper Overholm Elkrog",
   "keywords": [


### PR DESCRIPTION
## Describe your changes
* Improved stopping command to run commands in reverse.
* Added checks to ensure using 'dever [keyword] --stop' will no longer throw an error when docker container does not exist

## Issue ticket number and link
[#105 Cannot use 'dever [keyword] env --stop' if one of the docker containers hasn't been created.](../issues/105)

## Checklist before requesting a review
- ✔️ I have read and followed [guidelines for contributing](CONTRIBUTING.md) to this repository
- ✔️ I have performed a self-review of my code
- ✔️ I have made sure to create a pull request from a **topic/feature/bugfix** branch
- ✔️ I have followed the commit's or even all commits' message styles matches our requested structure.

Closes #105 