### PR TITLE
#88 Improved adding/removing projects when using 'init' by not clearing projects

### DIFF
--- a/bin/common/helper/powershell.js
+++ b/bin/common/helper/powershell.js
@@ -70,10 +70,10 @@ export default new class {
 
     /**
      * Check if execution should be run as elevated
-     * @param runAsElevated {boolean}
+     * @param elevated {boolean}
      * @return {Promise<boolean>}
      */
-    async #shouldRunElevated(runAsElevated) {
-        return runAsElevated && !await sudo.isElevated();
+    async #shouldRunElevated(elevated) {
+        return elevated && !await sudo.isElevated();
     }
 }


### PR DESCRIPTION
## Describe your changes
.dever projects list is no longer cleared when using 'dever init'.
Instead a comparison is done between list of dever.json files found and existing projects in .dever.
There by only removing projects not found again and only add new projects to .dever

## Issue ticket number and link
[#88 Improve init command to only modify projects when projects cannot be found or new found](../issues/88)

## Checklist before requesting a review
- ✔️ I have read and followed [guidelines for contributing](CONTRIBUTING.md) to this repository
- ✔️ I have performed a self-review of my code
- ✔️ I have made sure to create a pull request from a **topic/feature/bugfix** branch
- ✔️ I have followed the commit's or even all commits' message styles matches our requested structure.

Closes #88