### PR TITLE
#138 Fixed issue with option rule missing from schema

### DIFF
--- a/bin/common/schema/dever-json/v1.js
+++ b/bin/common/schema/dever-json/v1.js
@@ -95,7 +95,15 @@ const optionsSchema = {
         describe: {type: "string"},
         param: {type: "string"},
         required: {type: "boolean"},
-        // Todo: rule missing
+        rule: {
+            type: "object",
+            properties: {
+                match: {type: "string"},
+                message: {type: "string"}
+            },
+            required: ["match", "message"],
+            additionalProperties: false
+        },
         default: {
             anyOf: [
                 {


### PR DESCRIPTION
## Describe your changes
Added option rule to schema ensuring that validation of schema will not block functionality from being used

## Issue ticket number and link
[#138 Options rule not part of dever.json validation file. Causing rules cannot be used](../issues/138)

## Checklist before requesting a review
- ✔️ I have read and followed [guidelines for contributing](CONTRIBUTING.md) to this repository
- ✔️ I have performed a self-review of my code
- ✔️ I have made sure to create a pull request from a **topic/feature/bugfix** branch
- ✔️ I have followed the commit's or even all commits' message styles matches our requested structure.

Closes #138 
