### PR TITLE
#151 Fixed issue with no message displayed if using non-existing command

### DIFF
--- a/bin/execution/project-yargs-generator.js
+++ b/bin/execution/project-yargs-generator.js
@@ -1,6 +1,8 @@
 import projectConfigHandler from "../configuration/handlers/project-config-handler.js";
 import executorYargsGenerator from "./executor/executor-yargs-generator.js";
 
+import chalk from "chalk";
+
 "use strict";
 export default new class {
     /**
@@ -13,6 +15,12 @@ export default new class {
     create(keyword, project, yargs) {
         for (const segment of project.segments) {
             yargs
+                .command('$0', 'Show help', () => {}, () => {
+                    if (yargs.argv._.length > 0) {
+                        console.log(chalk.redBright('Invalid command or option'));
+                        yargs.showHelp();
+                    }
+                })
                 .command({
                     command: segment.key,
                     desc: segment.description,


### PR DESCRIPTION
## Describe your changes
Added default command which will handle any commands which doesn't end an expected place and informs user that any of the expected commands or options were hit

## Issue ticket number and link
[#151 User not being informed if cli command doesn't exist](../issues/151)

## Checklist before requesting a review
- ✔️ I have read and followed [guidelines for contributing](CONTRIBUTING.md) to this repository
- ✔️ I have performed a self-review of my code
- ✔️ I have made sure to create a pull request from a **topic/feature/bugfix** branch
- ✔️ I have followed the commit's or even all commits' message styles matches our requested structure.

Closes #151 