### PR TITLE
#152 Fixed issue with type not being defined when running env down command

### DIFF
--- a/bin/execution/executor/action-mapper.js
+++ b/bin/execution/executor/action-mapper.js
@@ -101,6 +101,10 @@ export default new class {
             return action.up[key];
         }
 
+        if (action.up != null && action.down == null && runtime.down) {
+            return action.up[key];
+        }
+
         if (action.down != null && runtime.down) {
             return action.down[key];
         }


### PR DESCRIPTION
## Describe your changes
Add logic to run down command from "up" if "down" doesn't exist in the dever.json

## Issue ticket number and link
[#152 down command is not working](../issues/152)

## Checklist before requesting a review
- ✔️ I have read and followed [guidelines for contributing](CONTRIBUTING.md) to this repository
- ✔️ I have performed a self-review of my code
- ✔️ I have made sure to create a pull request from a **topic/feature/bugfix** branch
- ✔️ I have followed the commit's or even all commits' message styles matches our requested structure.

Closes #152 