### PR TITLE
#99 Added logic for installing chocolatey if not available during usage of executions which needs it

### DIFF
--- a/bin/common/executor/executions/chocolatey/index.js
+++ b/bin/common/executor/executions/chocolatey/index.js
@@ -4,6 +4,7 @@ import chocolatey from "../../../helper/chocolatey.js";
 import {Runtime} from "../../../../execution/executor/runtime-mapper.js";
 import {Execute} from "../../../../execution/executor/action-mapper.js";
 import {ExecutionInterface} from "../../models.js";
+import {lastValueFrom} from "rxjs";
 
 "use strict";
 export default new class extends ExecutionInterface {
@@ -26,21 +27,32 @@ export default new class extends ExecutionInterface {
         }
     }
 
-    /**
-     * Install chocolatey
-     * return {Promise<ExecutionLog>}
-     */
     async _install() {
-        try {
-            this._started(Operation.DependencyInstallStarted);
-
-            if (await chocolatey.install()) {
-                return this._success(Operation.DependencyInstallFinished);
+        const install$ = chocolatey.logger;
+        const lastValueFromInstall$ = lastValueFrom(install$)
+        install$.subscribe(x => {
+            switch (x.state) {
+                case 'Started':
+                    this._started(Operation.DependencyInstallStarted);
+                    break;
             }
+        });
 
-            return this._error(Operation.DependencyInstallFinished);
-        } catch (error) {
-            return this._error(Operation.DependencyInstallFinished, error);
+        await chocolatey.install();
+
+        const lastValue = await lastValueFromInstall$;
+
+        switch (lastValue.state) {
+            case 'Success':
+                return this._success(Operation.DependencyInstallFinished);
+            case 'Error':
+                return this._error(Operation.DependencyInstallFinished, lastValue.error);
+            case 'NotElevated':
+                return this._warning(Operation.DependencyInstallNotElevated);
+            case 'Skipped':
+                return this._warning(Operation.DependencyInstallSkipped);
+            default:
+                return this._error(Operation.DependencyInstallFinished, new Error(`Unknown state: ${lastValue.state}`));
         }
     }
 
@@ -97,7 +109,9 @@ export const Operation = Object.freeze({
     Installed: 'installed',
     Uninstalling: 'uninstalling',
     Uninstalled: 'uninstalled',
+    DependencyInstallNotElevated: 'dependency-install-not-elevated',
     DependencyInstallStarted: 'dependency-install-started',
+    DependencyInstallSkipped: 'dependency-install-skipped',
     DependencyInstallFinished: 'dependency-install-finished',
     DependencyCheck: 'dependency-check'
 });

--- a/bin/common/executor/executions/chocolatey/index.js
+++ b/bin/common/executor/executions/chocolatey/index.js
@@ -1,4 +1,5 @@
 import shell from "../../../helper/shell.js";
+import chocolatey from "../../../helper/chocolatey.js";
 
 import {Runtime} from "../../../../execution/executor/runtime-mapper.js";
 import {Execute} from "../../../../execution/executor/action-mapper.js";
@@ -22,6 +23,24 @@ export default new class extends ExecutionInterface {
             return this._success(Operation.DependencyCheck);
         } catch (e) {
             return this._error(Operation.DependencyCheck);
+        }
+    }
+
+    /**
+     * Install chocolatey
+     * return {Promise<ExecutionLog>}
+     */
+    async _install() {
+        try {
+            this._started(Operation.DependencyInstallStarted);
+
+            if (await chocolatey.install()) {
+                return this._success(Operation.DependencyInstallFinished);
+            }
+
+            return this._error(Operation.DependencyInstallFinished);
+        } catch (error) {
+            return this._error(Operation.DependencyInstallFinished, error);
         }
     }
 
@@ -78,5 +97,7 @@ export const Operation = Object.freeze({
     Installed: 'installed',
     Uninstalling: 'uninstalling',
     Uninstalled: 'uninstalled',
+    DependencyInstallStarted: 'dependency-install-started',
+    DependencyInstallFinished: 'dependency-install-finished',
     DependencyCheck: 'dependency-check'
 });

--- a/bin/common/executor/index.js
+++ b/bin/common/executor/index.js
@@ -5,9 +5,6 @@ import powershell_command from "../../common/executor/executions/powershell-comm
 import mssql from "../../common/executor/executions/mssql/index.js";
 import chocolatey from "./executions/chocolatey/index.js";
 
-import {Execute} from "../../execution/executor/action-mapper.js";
-import {ExecutionLog, Status} from "./models.js";
-
 export default new class {
     /**
      * Get executor
@@ -31,45 +28,5 @@ export default new class {
             default:
                 throw new Error(`'${type}' type is not supported`);
         }
-    }
-
-    /**
-     * Check if all necessary dependencies are available
-     * @param executes {Execute[]}
-     * @return {Promise<ExecutionLog>}
-     */
-    async dependencyCheck(executes) {
-        let result;
-
-        for (const execute of executes) {
-            if (result?.status === Status.Error) {
-                return result;
-            }
-
-            switch (execute.type) {
-                case "docker-compose":
-                    result = docker_compose.check();
-                    break;
-                case "docker-container":
-                    result = docker_container.check();
-                    break;
-                case "powershell-script":
-                    result = powershell_script.check();
-                    break;
-                case "powershell-command":
-                    result = powershell_command.check();
-                    break;
-                case "mssql":
-                    result = mssql.check();
-                    break;
-                case "chocolatey":
-                    result = chocolatey.check();
-                    break;
-                default:
-                    throw new Error(`'${execute.type}' type is not supported`);
-            }
-        }
-
-        return new ExecutionLog(Status.Success, "dependency-check", "dependency-check");
     }
 }

--- a/bin/common/executor/models.js
+++ b/bin/common/executor/models.js
@@ -105,6 +105,13 @@ export class ExecutionInterface {
     }
 
     /**
+     * @return {Promise<ExecutionLog>}
+     */
+    async install() {
+        await this._install();
+    }
+
+    /**
      * @return {Promise<ExecutionLog> | ExecutionLog}
      */
     check() {
@@ -127,6 +134,15 @@ export class ExecutionInterface {
      */
     async _execute(execute, runtime) {
         throw new Error('ExecutorInterface._execute() is not implemented');
+    }
+
+    /**
+     * Install dependency
+     * @return {Promise<ExecutionLog>}
+     * @private
+     */
+    async _install() {
+        throw new Error('ExecutorInterface._install() is not implemented');
     }
 
     /**

--- a/bin/common/executor/models.js
+++ b/bin/common/executor/models.js
@@ -9,13 +9,16 @@ export class Informer {
 
     /**
      * Outputs response to the console
-     * @param type {'warning', 'error', 'success'}
+     * @param type {'warning', 'error', 'success', 'info'}
      * @param message {string}
      * @param error {Error | null}
      * @internal
      */
     _inform(type, message, error = null) {
         switch (type) {
+            case 'info':
+                logger.info(message);
+                break;
             case 'success':
                 logger.info(message);
                 break;

--- a/bin/common/executor/models.js
+++ b/bin/common/executor/models.js
@@ -108,7 +108,7 @@ export class ExecutionInterface {
      * @return {Promise<ExecutionLog>}
      */
     async install() {
-        await this._install();
+        return await this._install();
     }
 
     /**

--- a/bin/common/executor/responder/chocolatey/index.js
+++ b/bin/common/executor/responder/chocolatey/index.js
@@ -21,7 +21,8 @@ export default new class extends Informer {
                 this._inform_partial(log.status === Status.Success ? 'done' : 'failed', log);
                 break;
             case Operation.DependencyInstallNotElevated:
-                this._inform('warning', chalk.yellow('Chocolatey cannot be installed without elevated privileges. Please run the command again with elevated privileges.'));
+                this._inform('error', chalk.redBright('Chocolatey not installed and it requires elevated privileges to install it. \nPlease run the command again with elevated privileges.'));
+                this._inform('info', 'You can install chocolatey manually from https://chocolatey.org/install');
                 break;
             case Operation.DependencyInstallStarted:
                 this._inform_partial(`chocolatey is being installed... `, log);
@@ -33,7 +34,6 @@ export default new class extends Informer {
                 this._inform('warning', chalk.yellow('Chocolatey installation was skipped.'));
                 break;
             case Operation.DependencyCheck:
-                this._inform('error', `Chocolatey not installed. Please install chocolatey and retry command.`);
                 break;
         }
     }

--- a/bin/common/executor/responder/chocolatey/index.js
+++ b/bin/common/executor/responder/chocolatey/index.js
@@ -19,9 +19,14 @@ export default new class extends Informer {
             case Operation.Uninstalled:
                 this._inform_partial(log.status === Status.Success ? 'done' : 'failed', log);
                 break;
+            case Operation.DependencyInstallStarted:
+                this._inform_partial(`chocolatey is being installed... `, log);
+                break;
+            case Operation.DependencyInstallFinished:
+                this._inform_partial(log.status === Status.Success ? 'done' : 'failed', log);
+                break;
             case Operation.DependencyCheck:
                 this._inform('error', `Chocolatey not installed. Please install chocolatey and retry command.`);
-                this._inform('info', 'Please follow these steps for installing Chocolatey. https://chocolatey.org/install');
                 break;
         }
     }

--- a/bin/common/executor/responder/chocolatey/index.js
+++ b/bin/common/executor/responder/chocolatey/index.js
@@ -1,5 +1,6 @@
 import {Operation} from "../../executions/chocolatey/index.js";
 import {Informer, Status} from "../../models.js";
+import chalk from "chalk";
 
 export default new class extends Informer {
     /**
@@ -19,11 +20,17 @@ export default new class extends Informer {
             case Operation.Uninstalled:
                 this._inform_partial(log.status === Status.Success ? 'done' : 'failed', log);
                 break;
+            case Operation.DependencyInstallNotElevated:
+                this._inform('warning', chalk.yellow('Chocolatey cannot be installed without elevated privileges. Please run the command again with elevated privileges.'));
+                break;
             case Operation.DependencyInstallStarted:
                 this._inform_partial(`chocolatey is being installed... `, log);
                 break;
             case Operation.DependencyInstallFinished:
                 this._inform_partial(log.status === Status.Success ? 'done' : 'failed', log);
+                break;
+            case Operation.DependencyInstallSkipped:
+                this._inform('warning', chalk.yellow('Chocolatey installation was skipped.'));
                 break;
             case Operation.DependencyCheck:
                 this._inform('error', `Chocolatey not installed. Please install chocolatey and retry command.`);

--- a/bin/common/executor/responder/chocolatey/index.js
+++ b/bin/common/executor/responder/chocolatey/index.js
@@ -20,7 +20,8 @@ export default new class extends Informer {
                 this._inform_partial(log.status === Status.Success ? 'done' : 'failed', log);
                 break;
             case Operation.DependencyCheck:
-                this._inform('error', `Chocolatey not installed. Please install chocolatey and retry command`);
+                this._inform('error', `Chocolatey not installed. Please install chocolatey and retry command.`);
+                this._inform('info', 'Please follow these steps for installing Chocolatey. https://chocolatey.org/install');
                 break;
         }
     }

--- a/bin/common/helper/chocolatey.js
+++ b/bin/common/helper/chocolatey.js
@@ -1,0 +1,33 @@
+import powershell from "./powershell.js";
+import sudo from "./elevated.js";
+import delayer from "./delayer.js";
+import readline from "readline";
+
+export default new class {
+    async install() {
+        if (await sudo.isElevated()) {
+            return false;
+        }
+
+        const timer = delayer.create();
+
+        const rl = readline.createInterface(process.stdin, process.stdout);
+        await rl.question('Are you sure you want to install Chocolatey? [yes]/no:', async (answer) => {
+            if (answer.toLowerCase() === 'yes' || answer.toLowerCase() === 'y') {
+                try {
+                    powershell.executeSync('Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString(\'https://community.chocolatey.org/install.ps1\'))')
+                    timer.done(true);
+                } catch (e) {
+                    // TODO: Figure out how to pass exception for logging
+                    timer.done(false);
+                }
+            } else {
+                timer.done(false);
+            }
+
+            rl.close();
+        });
+
+        return timer.delay(36000000, false);
+    }
+}

--- a/bin/common/helper/delayer.js
+++ b/bin/common/helper/delayer.js
@@ -7,6 +7,13 @@ export default new class {
     create() {
         return new Delayer();
     }
+
+    delay(ms, callback) {
+        return new Promise(resolve => setTimeout(() => {
+            callback();
+            resolve();
+        }, ms));
+    }
 }
 
 class Delayer {

--- a/bin/common/helper/logger.js
+++ b/bin/common/helper/logger.js
@@ -100,7 +100,7 @@ export default new class Logger {
 
         console.warn(message);
 
-        Logger.#logger.log('warning', message);
+        Logger.#logger.log('warn', message);
         Logger.#hasLogs = true;
         Logger.#hasWarn = true;
     }

--- a/bin/execution/executor/dependency-checker.js
+++ b/bin/execution/executor/dependency-checker.js
@@ -1,0 +1,48 @@
+import executorHandler from "../../common/executor/index.js";
+import {Status} from "../../common/executor/models.js";
+import responder from "../../common/executor/responder/index.js";
+import chocolatey from "../../common/helper/chocolatey.js";
+
+export default new class {
+    /**
+     * Check if execution can run or not
+     * @param executables {Executable[]}
+     * @return {Promise<boolean>}
+     */
+    async check(executables) {
+        for (const executable of executables) {
+            const executor = await executorHandler.get(executable.type);
+
+            const executionLog = executor.check();
+            if (executionLog.status !== Status.Error) {
+                continue;
+            }
+
+            if (this.hasInstaller(executionLog)) {
+                const result = await executor.install()
+                if (result.status === Status.Error) {
+                    responder.respond(executionLog, null);
+                    return false;
+                }
+
+                return true;
+            }
+
+            responder.respond(executionLog, null);
+            return false;
+        }
+    }
+
+    /**
+     * Check if execution has installer
+     * @param log {ExecutionLog}
+     */
+    hasInstaller(log) {
+        switch (log.type) {
+            case "chocolatey":
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/bin/execution/executor/index.js
+++ b/bin/execution/executor/index.js
@@ -5,11 +5,11 @@ import {Runtime} from "./runtime-mapper.js";
 import actionMapper, {Execute, Executable} from "./action-mapper.js";
 import validator from "./validator.js";
 import elevatedConfirmer from "./elevated-confirmer.js";
+import dependencyChecker from "./dependency-checker.js";
 
 import chalk from "chalk";
 import {Subject, takeUntil} from "rxjs";
 import responder from "../../common/executor/responder/index.js";
-import {Status} from "../../common/executor/models.js";
 
 export default new class {
     /**
@@ -42,9 +42,7 @@ export default new class {
                     return;
                 }
 
-                const dependencyCheck = await executorHandler.dependencyCheck(executables);
-                if (dependencyCheck.status === Status.Error) {
-                    responder.respond(dependencyCheck, null);
+                if (!await dependencyChecker.check(executables)) {
                     return;
                 }
 


### PR DESCRIPTION
Installs Chocolatey for the user or informs them where to find out how they can do it themselves

## Describe your changes
Will now ask user to confirm installing chocolatey if not available or inform user where to find out how to install it themselves

## Issue ticket number and link
[#99 Add support for install chocolatey when using 'dever [keyword] install' and choco is not available](../issues/99)

## Checklist before requesting a review
- ✔️ I have read and followed [guidelines for contributing](CONTRIBUTING.md) to this repository
- ✔️ I have performed a self-review of my code
- ✔️ I have made sure to create a pull request from a **topic/feature/bugfix** branch
- ✔️ I have followed the commit's or even all commits' message styles matches our requested structure.

Closes #99 
