### PR TITLE
#164 Cannot execute runonce with old dever config files

### DIFF
--- a/bin/configuration/local-config.js
+++ b/bin/configuration/local-config.js
@@ -24,6 +24,13 @@ export default new class {
      */
     get() {
         const config = json.read(this.#filePath);
+        if (Object.keys(config).length === 0) {
+            return {
+                projects: [],
+                skipAllHashChecks: false
+            };
+        }
+
         const result = SchemaValidator.validate(SchemaTypes.DotDever, 1, config);
         if (!result) {
             throw new Error('.dever failed parsing. Please verify structure of the config file');

--- a/bin/configuration/local-config.js
+++ b/bin/configuration/local-config.js
@@ -23,19 +23,16 @@ export default new class {
      * @returns {Config}
      */
     get() {
-        const config = json.read(this.#filePath) ?? {projects: [], skipAllHashChecks: false};
-        // Todo: Temporary fix. Need to figure out a better way of handling upgrades of .dever
-        // noinspection JSUnresolvedVariable
-        if (config.components != null) {
-            return {projects: [], skipAllHashChecks: false};
-        }
-
+        const config = json.read(this.#filePath);
         const result = SchemaValidator.validate(SchemaTypes.DotDever, 1, config);
         if (!result) {
             throw new Error('.dever failed parsing. Please verify structure of the config file');
         }
 
-        return config;
+        return {
+            projects: config?.projects?.map(this.#projectMap) ?? [],
+            skipAllHashChecks: config?.skipAllHashChecks ?? false
+        };
     }
 
     /**
@@ -52,5 +49,14 @@ export default new class {
      */
     getFilePath() {
         return this.#filePath;
+    }
+
+    #projectMap(project) {
+        return {
+            path: project.path,
+            lastHash: project?.lastHash,
+            skipHashCheck: project?.skipHashCheck ?? false,
+            hasRunActions: project?.hasRunActions ?? []
+        }
     }
 }


### PR DESCRIPTION
## Describe your changes
Added logic on reading .dever to ensure all properties are set as expected.

## Issue ticket number and link
#164 Cannot execute runOnce with old .dever config files](../issues/164)

## Checklist before requesting a review
- ✔️ I have read and followed [guidelines for contributing](CONTRIBUTING.md) to this repository
- ✔️ I have performed a self-review of my code
- ✔️ I have made sure to create a pull request from a **topic/feature/bugfix** branch
- ✔️ I have followed the commit's or even all commits' message styles matches our requested structure.

Closes #164 
