### PR TITLE
#176 Fixed issue with not supporting actions with only down executions

### DIFF
--- a/bin/execution/executor/action-mapper.js
+++ b/bin/execution/executor/action-mapper.js
@@ -41,6 +41,10 @@ export default new class {
             return false;
         }
 
+        if (action.container == null && action.down == null && runtime.down) {
+            return false;
+        }
+
         return !(runtime.exclude.executions.length > 0 && runtime.exclude.executions.some(x => x.toLowerCase() === lowerCaseName) ||
             runtime.exclude.groups.length > 0 && runtime.exclude.groups.some(x => x.toLowerCase() === lowerCaseGroup));
     }

--- a/bin/execution/executor/action-mapper.js
+++ b/bin/execution/executor/action-mapper.js
@@ -41,12 +41,12 @@ export default new class {
             return false;
         }
 
-        if (action.container == null && action.down == null && runtime.down) {
+        if (!this.#hasUp(action) && runtime.up ||
+            !this.#hasDown(action) && runtime.down) {
             return false;
         }
 
-        return !(runtime.exclude.executions.length > 0 && runtime.exclude.executions.some(x => x.toLowerCase() === lowerCaseName) ||
-            runtime.exclude.groups.length > 0 && runtime.exclude.groups.some(x => x.toLowerCase() === lowerCaseGroup));
+        return !(runtime.exclude.executions.length > 0 && runtime.exclude.executions.some(x => x.toLowerCase() === lowerCaseName) || runtime.exclude.groups.length > 0 && runtime.exclude.groups.some(x => x.toLowerCase() === lowerCaseGroup));
     }
 
     /**
@@ -92,8 +92,7 @@ export default new class {
         }
 
         return {
-            when: wait.when,
-            seconds: wait.time
+            when: wait.when, seconds: wait.time
         };
     }
 
@@ -118,6 +117,38 @@ export default new class {
         }
 
         return action[key];
+    }
+
+    /**
+     * Checks if action has any up executions
+     * @param action {Action}
+     * @return {boolean}
+     */
+    #hasUp(action) {
+        return action.up != null ||
+            this.#hasAnyGenerics(action);
+    }
+
+    /**
+     * Check if action has any down executions
+     * @param action {Action}
+     * @return {boolean}
+     */
+    #hasDown(action) {
+        return action.down != null ||
+            this.#hasAnyGenerics(action);
+    }
+
+    /**
+     * Checks for any generic executions
+     * @param action {Action}
+     */
+    #hasAnyGenerics(action) {
+        return action.container != null ||
+            action.file != null ||
+            action.command != null ||
+            action.package != null ||
+            action.sql != null;
     }
 }
 

--- a/bin/execution/executor/action-mapper.js
+++ b/bin/execution/executor/action-mapper.js
@@ -46,7 +46,8 @@ export default new class {
             return false;
         }
 
-        return !(runtime.exclude.executions.length > 0 && runtime.exclude.executions.some(x => x.toLowerCase() === lowerCaseName) || runtime.exclude.groups.length > 0 && runtime.exclude.groups.some(x => x.toLowerCase() === lowerCaseGroup));
+        return !(runtime.exclude.executions.length > 0 && runtime.exclude.executions.some(x => x.toLowerCase() === lowerCaseName) ||
+            runtime.exclude.groups.length > 0 && runtime.exclude.groups.some(x => x.toLowerCase() === lowerCaseGroup));
     }
 
     /**
@@ -92,7 +93,8 @@ export default new class {
         }
 
         return {
-            when: wait.when, seconds: wait.time
+            when: wait.when,
+            seconds: wait.time
         };
     }
 


### PR DESCRIPTION
## Describe your changes
Added filtering that will ignore actions with only up on down (except containers) and the same for up if only down has been configured

## Issue ticket number and link
[#176 'dever [segment] [keyword] down' runs through all steps regardless of whether they actually have a down functionality](../issues/176)

## Checklist before requesting a review
- ✔️ I have read and followed [guidelines for contributing](CONTRIBUTING.md) to this repository
- ✔️ I have performed a self-review of my code
- ✔️ I have made sure to create a pull request from a **topic/feature/bugfix** branch
- ✔️ I have followed the commit's or even all commits' message styles matches our requested structure.

Closes #176 
