### PR TITLE
#203 Fixed issue with error being thrown if latestVersion is null

### DIFF
--- a/bin/common/schema/dot-dever/v1.js
+++ b/bin/common/schema/dot-dever/v1.js
@@ -27,7 +27,7 @@ export default {
         },
         skipAllHashChecks: {type: "boolean"},
         lastVersionCheckMs: {type: "number"},
-        latestVersion: {type: "string"}
+        latestVersion: {type: ["string", "null"]}
     },
     required: ["projects", "skipAllHashChecks"],
     additionalProperties: false

--- a/bin/common/version-checker/index.js
+++ b/bin/common/version-checker/index.js
@@ -25,8 +25,10 @@ export default new class {
             return;
         }
 
+        this.#hasChecked();
+
         const version = ConfigFacade.getSingle((config) => config.latestVersion);
-        if (version === "0.0.0") {
+        if (version == null) {
             return;
         }
 
@@ -46,17 +48,26 @@ export default new class {
             console.log(`\n\n${chalk.greenBright(`@czprz/dever ${newestVersion.full} is now available`)}`);
             console.log(`\nUse ${chalk.blueBright('npm update -g @czprz/dever')} for upgrading to latest version`);
         }
-
-        ConfigFacade.update(config => {
-            config.lastVersionCheckMs = Date.now();
-        });
     }
 
+    /**
+     * Ensures version check doesn't occur too often. If e.g. it's not able to fetch version
+     * @returns {boolean}
+     */
     #conditionForVersionChecking() {
         const lastVersionCheckMs = ConfigFacade.getSingle(config => config?.lastVersionCheckMs);
         const now = Date.now();
 
         return now > lastVersionCheckMs + 86400000;
+    }
+
+    /**
+     * Informs .dever that user has run version check
+     */
+    #hasChecked() {
+        ConfigFacade.update(config => {
+            config.lastVersionCheckMs = Date.now();
+        });
     }
 
     /**

--- a/bin/common/version-checker/index.js
+++ b/bin/common/version-checker/index.js
@@ -26,7 +26,7 @@ export default new class {
         }
 
         const version = ConfigFacade.getSingle((config) => config.latestVersion);
-        if (version == null) {
+        if (version === "0.0.0") {
             return;
         }
 

--- a/bin/configuration/local-config.js
+++ b/bin/configuration/local-config.js
@@ -40,7 +40,7 @@ export default new class {
             projects: config?.projects?.map(this.#projectMap) ?? [],
             skipAllHashChecks: config?.skipAllHashChecks ?? false,
             lastVersionCheckMs: config?.lastVersionCheckMs ?? 0,
-            latestVersion: config?.latestVersion ?? "0.0.0"
+            latestVersion: config?.latestVersion ?? null
         };
     }
 

--- a/bin/configuration/local-config.js
+++ b/bin/configuration/local-config.js
@@ -40,7 +40,7 @@ export default new class {
             projects: config?.projects?.map(this.#projectMap) ?? [],
             skipAllHashChecks: config?.skipAllHashChecks ?? false,
             lastVersionCheckMs: config?.lastVersionCheckMs ?? 0,
-            latestVersion: config?.latestVersion ?? null
+            latestVersion: config?.latestVersion ?? "0.0.0"
         };
     }
 


### PR DESCRIPTION
## Describe your changes
Modified schema validation rules to allow null in 'latestVersion' and changed location at when saving of lastVersionCheckMs is occurred to ensure it isn't executed too often if e.g. it wouldn't be able to fetch the version

## Issue ticket number and link
[#203 After adding 'latestVersion' as null to .dever application is not able to start due to schema validation expecting a string](../issues/203)

## Checklist before requesting a review
- ✔️ I have read and followed [guidelines for contributing](CONTRIBUTING.md) to this repository
- ✔️ I have performed a self-review of my code
- ✔️ I have made sure to create a pull request from a **topic/feature/bugfix** branch
- ✔️ I have followed the commit's or even all commits' message styles matches our requested structure.

Closes #203 
